### PR TITLE
Add auto kick for inactive members

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,7 @@ import './lib/setup';
 import { LogLevel, SapphireClient } from '@sapphire/framework';
 import { GatewayIntentBits } from 'discord.js';
 import { database } from './database';
-
-
+import { CheckActivity } from './utils/checkActivity';
 
 export const client = new SapphireClient({
 	defaultPrefix: process.env.PREFIX,
@@ -33,6 +32,7 @@ const main = async () => {
 		client.logger.info('Logging in');
 		await client.login();
 		client.logger.info('logged in');
+		await CheckActivity(client.guilds.cache.get('1253817742054654075'));
 	} catch (error) {
 		client.logger.fatal(error);
 		await client.destroy();


### PR DESCRIPTION
Add auto kick functionality for inactive members.

* Import `CheckActivity` in `src/index.ts` and call it after the client logs in.
* Update `CheckActivity` function in `src/utils/checkActivity.ts` to:
  - Send a direct message to inactive members.
  - Handle cases where the bot cannot message the user.
  - Send an embed in the `dev-notify` channel if the bot cannot message the user.
  - Add buttons to the embed for staff to decide whether to kick the member.
  - Handle button interactions to kick or not kick the member based on staff decision.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Tjens23/MSRT-BOT/pull/18?shareId=c7036f62-5981-43ca-b056-1a0d8ab508c2).