### PR TITLE
feat(logging): add comprehensive logging listeners for various events

### DIFF
--- a/src/listeners/guildMemberAdd.ts
+++ b/src/listeners/guildMemberAdd.ts
@@ -1,5 +1,5 @@
 import { Listener } from '@sapphire/framework';
-import { ChannelType, Colors, EmbedBuilder, GuildMember, Role, TextChannel } from 'discord.js';
+import { ChannelType, Colors, EmbedBuilder, GuildMember, TextChannel } from 'discord.js';
 import { database } from '../database';
 import User from '../database/entities/User';
 import { UserActivity } from '../database/entities/UserActivity';

--- a/src/listeners/logging/channelCreate.ts
+++ b/src/listeners/logging/channelCreate.ts
@@ -1,0 +1,38 @@
+import { Listener } from '@sapphire/framework';
+import { ChannelType, GuildChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class ChannelCreateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'channelCreate'
+		});
+	}
+
+	public async run(channel: GuildChannel): Promise<void> {
+		if (!channel.guild) return;
+
+		const channelTypes: Record<number, string> = {
+			[ChannelType.GuildText]: 'Text',
+			[ChannelType.GuildVoice]: 'Voice',
+			[ChannelType.GuildCategory]: 'Category',
+			[ChannelType.GuildAnnouncement]: 'Announcement',
+			[ChannelType.GuildStageVoice]: 'Stage',
+			[ChannelType.GuildForum]: 'Forum'
+		};
+
+		await sendAuditLog({
+			guild: channel.guild,
+			eventType: 'CHANNEL_CREATE',
+			title: 'Channel Created',
+			fields: [
+				{ name: 'Channel', value: `${channel} (${channel.name})`, inline: true },
+				{ name: 'Type', value: channelTypes[channel.type] || 'Unknown', inline: true },
+				{ name: 'ID', value: channel.id, inline: true },
+				{ name: 'Category', value: channel.parent?.name || 'None', inline: true }
+			],
+			footer: `Channel ID: ${channel.id}`
+		});
+	}
+}

--- a/src/listeners/logging/channelDelete.ts
+++ b/src/listeners/logging/channelDelete.ts
@@ -1,0 +1,41 @@
+import { Listener } from '@sapphire/framework';
+import { ChannelType, DMChannel, GuildChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class ChannelDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'channelDelete'
+		});
+	}
+
+	public async run(channel: DMChannel | GuildChannel): Promise<void> {
+		if (channel.type === ChannelType.DM) return;
+
+		const guildChannel = channel as GuildChannel;
+		if (!guildChannel.guild) return;
+
+		const channelTypes: Record<number, string> = {
+			[ChannelType.GuildText]: 'Text',
+			[ChannelType.GuildVoice]: 'Voice',
+			[ChannelType.GuildCategory]: 'Category',
+			[ChannelType.GuildAnnouncement]: 'Announcement',
+			[ChannelType.GuildStageVoice]: 'Stage',
+			[ChannelType.GuildForum]: 'Forum'
+		};
+
+		await sendAuditLog({
+			guild: guildChannel.guild,
+			eventType: 'CHANNEL_DELETE',
+			title: 'Channel Deleted',
+			fields: [
+				{ name: 'Channel Name', value: guildChannel.name, inline: true },
+				{ name: 'Type', value: channelTypes[guildChannel.type] || 'Unknown', inline: true },
+				{ name: 'ID', value: guildChannel.id, inline: true },
+				{ name: 'Category', value: guildChannel.parent?.name || 'None', inline: true }
+			],
+			footer: `Channel ID: ${guildChannel.id}`
+		});
+	}
+}

--- a/src/listeners/logging/channelUpdate.ts
+++ b/src/listeners/logging/channelUpdate.ts
@@ -1,0 +1,80 @@
+import { Listener } from '@sapphire/framework';
+import { ChannelType, DMChannel, GuildChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class ChannelUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'channelUpdate'
+		});
+	}
+
+	public async run(oldChannel: DMChannel | GuildChannel, newChannel: DMChannel | GuildChannel): Promise<void> {
+		if (oldChannel.type === ChannelType.DM || newChannel.type === ChannelType.DM) return;
+
+		const oldGuildChannel = oldChannel as GuildChannel;
+		const newGuildChannel = newChannel as GuildChannel;
+		if (!newGuildChannel.guild) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		if (oldGuildChannel.name !== newGuildChannel.name) {
+			changes.push({ name: 'Name', value: `${oldGuildChannel.name} → ${newGuildChannel.name}`, inline: true });
+		}
+
+		if (oldGuildChannel.parentId !== newGuildChannel.parentId) {
+			changes.push({
+				name: 'Category',
+				value: `${oldGuildChannel.parent?.name || 'None'} → ${newGuildChannel.parent?.name || 'None'}`,
+				inline: true
+			});
+		}
+
+		if (oldGuildChannel.position !== newGuildChannel.position) {
+			changes.push({
+				name: 'Position',
+				value: `${oldGuildChannel.position} → ${newGuildChannel.position}`,
+				inline: true
+			});
+		}
+
+		// Check for text channel specific changes
+		if (oldGuildChannel.type === ChannelType.GuildText && newGuildChannel.type === ChannelType.GuildText) {
+			const oldText = oldGuildChannel as any;
+			const newText = newGuildChannel as any;
+
+			if (oldText.topic !== newText.topic) {
+				changes.push({
+					name: 'Topic',
+					value: `${oldText.topic || 'None'} → ${newText.topic || 'None'}`,
+					inline: false
+				});
+			}
+
+			if (oldText.nsfw !== newText.nsfw) {
+				changes.push({ name: 'NSFW', value: `${oldText.nsfw} → ${newText.nsfw}`, inline: true });
+			}
+
+			if (oldText.rateLimitPerUser !== newText.rateLimitPerUser) {
+				changes.push({
+					name: 'Slowmode',
+					value: `${oldText.rateLimitPerUser}s → ${newText.rateLimitPerUser}s`,
+					inline: true
+				});
+			}
+		}
+
+		if (changes.length === 0) return;
+
+		changes.unshift({ name: 'Channel', value: `${newGuildChannel} (${newGuildChannel.name})`, inline: true });
+
+		await sendAuditLog({
+			guild: newGuildChannel.guild,
+			eventType: 'CHANNEL_UPDATE',
+			title: 'Channel Updated',
+			fields: changes,
+			footer: `Channel ID: ${newGuildChannel.id}`
+		});
+	}
+}

--- a/src/listeners/logging/emojiCreate.ts
+++ b/src/listeners/logging/emojiCreate.ts
@@ -1,0 +1,29 @@
+import { Listener } from '@sapphire/framework';
+import { GuildEmoji } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class EmojiCreateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'emojiCreate'
+		});
+	}
+
+	public async run(emoji: GuildEmoji): Promise<void> {
+		if (!emoji.guild) return;
+
+		await sendAuditLog({
+			guild: emoji.guild,
+			eventType: 'EMOJI_CREATE',
+			title: 'Emoji Created',
+			fields: [
+				{ name: 'Emoji', value: `${emoji} \`:${emoji.name}:\``, inline: true },
+				{ name: 'Animated', value: emoji.animated ? 'Yes' : 'No', inline: true },
+				{ name: 'Created By', value: emoji.author?.tag || 'Unknown', inline: true }
+			],
+			thumbnail: emoji.url,
+			footer: `Emoji ID: ${emoji.id}`
+		});
+	}
+}

--- a/src/listeners/logging/emojiDelete.ts
+++ b/src/listeners/logging/emojiDelete.ts
@@ -1,0 +1,28 @@
+import { Listener } from '@sapphire/framework';
+import { GuildEmoji } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class EmojiDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'emojiDelete'
+		});
+	}
+
+	public async run(emoji: GuildEmoji): Promise<void> {
+		if (!emoji.guild) return;
+
+		await sendAuditLog({
+			guild: emoji.guild,
+			eventType: 'EMOJI_DELETE',
+			title: 'Emoji Deleted',
+			fields: [
+				{ name: 'Emoji Name', value: `:${emoji.name}:`, inline: true },
+				{ name: 'Animated', value: emoji.animated ? 'Yes' : 'No', inline: true }
+			],
+			thumbnail: emoji.url,
+			footer: `Emoji ID: ${emoji.id}`
+		});
+	}
+}

--- a/src/listeners/logging/emojiUpdate.ts
+++ b/src/listeners/logging/emojiUpdate.ts
@@ -1,0 +1,33 @@
+import { Listener } from '@sapphire/framework';
+import { GuildEmoji } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class EmojiUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'emojiUpdate'
+		});
+	}
+
+	public async run(oldEmoji: GuildEmoji, newEmoji: GuildEmoji): Promise<void> {
+		if (!newEmoji.guild) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		if (oldEmoji.name !== newEmoji.name) {
+			changes.push({ name: 'Name', value: `:${oldEmoji.name}: → :${newEmoji.name}:`, inline: true });
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild: newEmoji.guild,
+			eventType: 'EMOJI_UPDATE',
+			title: 'Emoji Updated',
+			fields: [{ name: 'Emoji', value: `${newEmoji}`, inline: true }, ...changes],
+			thumbnail: newEmoji.url,
+			footer: `Emoji ID: ${newEmoji.id}`
+		});
+	}
+}

--- a/src/listeners/logging/guildBanAdd.ts
+++ b/src/listeners/logging/guildBanAdd.ts
@@ -1,0 +1,30 @@
+import { Listener } from '@sapphire/framework';
+import { GuildBan } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class GuildBanAddListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'guildBanAdd'
+		});
+	}
+
+	public async run(ban: GuildBan): Promise<void> {
+		if (!ban.guild) return;
+
+		await sendAuditLog({
+			guild: ban.guild,
+			eventType: 'MEMBER_BAN',
+			title: 'Member Banned',
+			description: `${ban.user.tag} was banned from the server.`,
+			fields: [
+				{ name: 'User', value: `${ban.user.tag}`, inline: true },
+				{ name: 'ID', value: ban.user.id, inline: true },
+				{ name: 'Reason', value: ban.reason || 'No reason provided', inline: false }
+			],
+			thumbnail: ban.user.displayAvatarURL(),
+			footer: `User ID: ${ban.user.id}`
+		});
+	}
+}

--- a/src/listeners/logging/guildBanRemove.ts
+++ b/src/listeners/logging/guildBanRemove.ts
@@ -1,0 +1,29 @@
+import { Listener } from '@sapphire/framework';
+import { GuildBan } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class GuildBanRemoveListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'guildBanRemove'
+		});
+	}
+
+	public async run(ban: GuildBan): Promise<void> {
+		if (!ban.guild) return;
+
+		await sendAuditLog({
+			guild: ban.guild,
+			eventType: 'MEMBER_UNBAN',
+			title: 'Member Unbanned',
+			description: `${ban.user.tag} was unbanned from the server.`,
+			fields: [
+				{ name: 'User', value: `${ban.user.tag}`, inline: true },
+				{ name: 'ID', value: ban.user.id, inline: true }
+			],
+			thumbnail: ban.user.displayAvatarURL(),
+			footer: `User ID: ${ban.user.id}`
+		});
+	}
+}

--- a/src/listeners/logging/guildMemberRemove.ts
+++ b/src/listeners/logging/guildMemberRemove.ts
@@ -1,0 +1,38 @@
+import { Listener } from '@sapphire/framework';
+import { GuildMember, PartialGuildMember } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class GuildMemberRemoveListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'guildMemberRemove'
+		});
+	}
+
+	public async run(member: GuildMember | PartialGuildMember): Promise<void> {
+		if (!member.guild) return;
+
+		const roles = member.roles?.cache
+			.filter((r) => r.id !== member.guild.id)
+			.map((r) => r.name)
+			.join(', ');
+
+		const joinedAt = member.joinedAt ? `<t:${Math.floor(member.joinedAt.getTime() / 1000)}:R>` : 'Unknown';
+
+		await sendAuditLog({
+			guild: member.guild,
+			eventType: 'MEMBER_LEAVE',
+			title: 'Member Left',
+			description: `${member.user?.tag || 'Unknown'} has left the server.`,
+			fields: [
+				{ name: 'User', value: `${member.user?.tag || 'Unknown'}`, inline: true },
+				{ name: 'ID', value: member.id, inline: true },
+				{ name: 'Joined', value: joinedAt, inline: true },
+				{ name: 'Roles', value: roles || 'None', inline: false }
+			],
+			thumbnail: member.user?.displayAvatarURL() || undefined,
+			footer: `User ID: ${member.id}`
+		});
+	}
+}

--- a/src/listeners/logging/guildMemberUpdateLog.ts
+++ b/src/listeners/logging/guildMemberUpdateLog.ts
@@ -1,0 +1,92 @@
+import { Listener } from '@sapphire/framework';
+import { GuildMember, PartialGuildMember } from 'discord.js';
+import { sendAuditLog, truncateString } from '../../utils/auditLogger';
+
+export class GuildMemberUpdateLogListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'guildMemberUpdate'
+		});
+	}
+
+	public async run(oldMember: GuildMember | PartialGuildMember, newMember: GuildMember): Promise<void> {
+		if (!newMember.guild) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		// Nickname change
+		if (oldMember.nickname !== newMember.nickname) {
+			changes.push({
+				name: 'Nickname',
+				value: `${oldMember.nickname || 'None'} → ${newMember.nickname || 'None'}`,
+				inline: true
+			});
+		}
+
+		// Role changes
+		const oldRoles = oldMember.roles?.cache || new Map();
+		const newRoles = newMember.roles.cache;
+
+		const addedRoles = newRoles.filter((role) => !oldRoles.has(role.id) && role.id !== newMember.guild.id);
+		const removedRoles = oldRoles.filter((role) => !newRoles.has(role.id) && role.id !== newMember.guild.id);
+
+		if (addedRoles.size > 0) {
+			changes.push({
+				name: 'Roles Added',
+				value: truncateString(addedRoles.map((r) => r.name).join(', ')),
+				inline: true
+			});
+		}
+
+		if (removedRoles.size > 0) {
+			changes.push({
+				name: 'Roles Removed',
+				value: truncateString(removedRoles.map((r) => r.name).join(', ')),
+				inline: true
+			});
+		}
+
+		// Timeout change
+		if (oldMember.communicationDisabledUntilTimestamp !== newMember.communicationDisabledUntilTimestamp) {
+			if (newMember.communicationDisabledUntil) {
+				changes.push({
+					name: 'Timed Out Until',
+					value: `<t:${Math.floor(newMember.communicationDisabledUntil.getTime() / 1000)}:F>`,
+					inline: true
+				});
+			} else if (oldMember.communicationDisabledUntil) {
+				changes.push({
+					name: 'Timeout',
+					value: 'Removed',
+					inline: true
+				});
+			}
+		}
+
+		// Avatar change
+		if (oldMember.avatar !== newMember.avatar) {
+			changes.push({
+				name: 'Server Avatar',
+				value: newMember.avatar ? 'Updated' : 'Removed',
+				inline: true
+			});
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild: newMember.guild,
+			eventType: 'MEMBER_UPDATE',
+			title: 'Member Updated',
+			description: `${newMember.user.tag}'s profile was updated.`,
+			fields: [
+				{ name: 'User', value: `${newMember} (${newMember.user.tag})`, inline: true },
+				{ name: 'ID', value: newMember.id, inline: true },
+				...changes
+			],
+			thumbnail: newMember.displayAvatarURL(),
+			footer: `User ID: ${newMember.id}`
+		});
+	}
+}

--- a/src/listeners/logging/guildUpdate.ts
+++ b/src/listeners/logging/guildUpdate.ts
@@ -1,0 +1,95 @@
+import { Listener } from '@sapphire/framework';
+import { Guild } from 'discord.js';
+import { sendAuditLog, truncateString } from '../../utils/auditLogger';
+
+export class GuildUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'guildUpdate'
+		});
+	}
+
+	public async run(oldGuild: Guild, newGuild: Guild): Promise<void> {
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		if (oldGuild.name !== newGuild.name) {
+			changes.push({ name: 'Name', value: `${oldGuild.name} → ${newGuild.name}`, inline: true });
+		}
+
+		if (oldGuild.icon !== newGuild.icon) {
+			changes.push({ name: 'Icon', value: 'Updated', inline: true });
+		}
+
+		if (oldGuild.banner !== newGuild.banner) {
+			changes.push({ name: 'Banner', value: newGuild.banner ? 'Updated' : 'Removed', inline: true });
+		}
+
+		if (oldGuild.description !== newGuild.description) {
+			changes.push({
+				name: 'Description',
+				value: truncateString(`${oldGuild.description || 'None'} → ${newGuild.description || 'None'}`),
+				inline: false
+			});
+		}
+
+		if (oldGuild.verificationLevel !== newGuild.verificationLevel) {
+			changes.push({
+				name: 'Verification Level',
+				value: `${oldGuild.verificationLevel} → ${newGuild.verificationLevel}`,
+				inline: true
+			});
+		}
+
+		if (oldGuild.explicitContentFilter !== newGuild.explicitContentFilter) {
+			changes.push({
+				name: 'Explicit Content Filter',
+				value: `${oldGuild.explicitContentFilter} → ${newGuild.explicitContentFilter}`,
+				inline: true
+			});
+		}
+
+		if (oldGuild.afkChannelId !== newGuild.afkChannelId) {
+			changes.push({
+				name: 'AFK Channel',
+				value: `${oldGuild.afkChannel?.name || 'None'} → ${newGuild.afkChannel?.name || 'None'}`,
+				inline: true
+			});
+		}
+
+		if (oldGuild.afkTimeout !== newGuild.afkTimeout) {
+			changes.push({
+				name: 'AFK Timeout',
+				value: `${oldGuild.afkTimeout / 60}min → ${newGuild.afkTimeout / 60}min`,
+				inline: true
+			});
+		}
+
+		if (oldGuild.systemChannelId !== newGuild.systemChannelId) {
+			changes.push({
+				name: 'System Channel',
+				value: `${oldGuild.systemChannel?.name || 'None'} → ${newGuild.systemChannel?.name || 'None'}`,
+				inline: true
+			});
+		}
+
+		if (oldGuild.ownerId !== newGuild.ownerId) {
+			changes.push({
+				name: 'Owner',
+				value: `<@${oldGuild.ownerId}> → <@${newGuild.ownerId}>`,
+				inline: true
+			});
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild: newGuild,
+			eventType: 'GUILD_UPDATE',
+			title: 'Server Updated',
+			fields: changes,
+			thumbnail: newGuild.iconURL() || undefined,
+			footer: `Guild ID: ${newGuild.id}`
+		});
+	}
+}

--- a/src/listeners/logging/inviteCreate.ts
+++ b/src/listeners/logging/inviteCreate.ts
@@ -1,0 +1,33 @@
+import { Listener } from '@sapphire/framework';
+import { Invite } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class InviteCreateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'inviteCreate'
+		});
+	}
+
+	public async run(invite: Invite): Promise<void> {
+		if (!invite.guild) return;
+
+		const expiresAt = invite.expiresAt ? `<t:${Math.floor(invite.expiresAt.getTime() / 1000)}:R>` : 'Never';
+
+		await sendAuditLog({
+			guild: invite.guild,
+			eventType: 'INVITE_CREATE',
+			title: 'Invite Created',
+			fields: [
+				{ name: 'Code', value: invite.code, inline: true },
+				{ name: 'Channel', value: invite.channel?.name || 'Unknown', inline: true },
+				{ name: 'Created By', value: invite.inviter?.tag || 'Unknown', inline: true },
+				{ name: 'Max Uses', value: invite.maxUses?.toString() || 'Unlimited', inline: true },
+				{ name: 'Expires', value: expiresAt, inline: true },
+				{ name: 'Temporary', value: invite.temporary ? 'Yes' : 'No', inline: true }
+			],
+			footer: `Invite Code: ${invite.code}`
+		});
+	}
+}

--- a/src/listeners/logging/inviteDelete.ts
+++ b/src/listeners/logging/inviteDelete.ts
@@ -1,0 +1,28 @@
+import { Listener } from '@sapphire/framework';
+import { Invite } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class InviteDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'inviteDelete'
+		});
+	}
+
+	public async run(invite: Invite): Promise<void> {
+		if (!invite.guild) return;
+
+		await sendAuditLog({
+			guild: invite.guild,
+			eventType: 'INVITE_DELETE',
+			title: 'Invite Deleted',
+			fields: [
+				{ name: 'Code', value: invite.code, inline: true },
+				{ name: 'Channel', value: invite.channel?.name || 'Unknown', inline: true },
+				{ name: 'Uses', value: invite.uses?.toString() || 'Unknown', inline: true }
+			],
+			footer: `Invite Code: ${invite.code}`
+		});
+	}
+}

--- a/src/listeners/logging/messageDelete.ts
+++ b/src/listeners/logging/messageDelete.ts
@@ -1,0 +1,35 @@
+import { Listener } from '@sapphire/framework';
+import { Message, PartialMessage, TextChannel } from 'discord.js';
+import { sendAuditLog, truncateString } from '../../utils/auditLogger';
+
+export class MessageDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'messageDelete'
+		});
+	}
+
+	public async run(message: Message | PartialMessage): Promise<void> {
+		// Ignore DMs and bot messages
+		if (!message.guild || message.author?.bot) return;
+
+		const channel = message.channel as TextChannel;
+		const content = message.content || 'No content (embed or attachment)';
+		const attachments = message.attachments?.size ? message.attachments.map((a) => a.name).join(', ') : 'None';
+
+		await sendAuditLog({
+			guild: message.guild,
+			eventType: 'MESSAGE_DELETE',
+			title: 'Message Deleted',
+			fields: [
+				{ name: 'Author', value: message.author?.tag || 'Unknown', inline: true },
+				{ name: 'Channel', value: `${channel} (${channel.name})`, inline: true },
+				{ name: 'Content', value: truncateString(content), inline: false },
+				{ name: 'Attachments', value: truncateString(attachments), inline: true }
+			],
+			thumbnail: message.author?.displayAvatarURL(),
+			footer: `Message ID: ${message.id} | Author ID: ${message.author?.id || 'Unknown'}`
+		});
+	}
+}

--- a/src/listeners/logging/messageDeleteBulk.ts
+++ b/src/listeners/logging/messageDeleteBulk.ts
@@ -1,0 +1,32 @@
+import { Listener } from '@sapphire/framework';
+import { Collection, Message, PartialMessage, Snowflake, TextChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class MessageDeleteBulkListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'messageDeleteBulk'
+		});
+	}
+
+	public async run(messages: Collection<Snowflake, Message | PartialMessage>, channel: TextChannel): Promise<void> {
+		if (!channel.guild) return;
+
+		const authors = [...new Set(messages.map((m) => m.author?.tag || 'Unknown'))];
+		const authorsStr = authors.slice(0, 10).join(', ') + (authors.length > 10 ? ` and ${authors.length - 10} more` : '');
+
+		await sendAuditLog({
+			guild: channel.guild,
+			eventType: 'MESSAGE_BULK_DELETE',
+			title: 'Bulk Message Delete',
+			description: `${messages.size} messages were deleted in ${channel}.`,
+			fields: [
+				{ name: 'Channel', value: `${channel} (${channel.name})`, inline: true },
+				{ name: 'Message Count', value: messages.size.toString(), inline: true },
+				{ name: 'Authors', value: authorsStr || 'Unknown', inline: false }
+			],
+			footer: `Channel ID: ${channel.id}`
+		});
+	}
+}

--- a/src/listeners/logging/messageUpdate.ts
+++ b/src/listeners/logging/messageUpdate.ts
@@ -1,0 +1,35 @@
+import { Listener } from '@sapphire/framework';
+import { Message, PartialMessage, TextChannel } from 'discord.js';
+import { sendAuditLog, truncateString } from '../../utils/auditLogger';
+
+export class MessageUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'messageUpdate'
+		});
+	}
+
+	public async run(oldMessage: Message | PartialMessage, newMessage: Message | PartialMessage): Promise<void> {
+		// Ignore DMs, bot messages, and embeds loading
+		if (!newMessage.guild || newMessage.author?.bot) return;
+		if (oldMessage.content === newMessage.content) return;
+
+		const channel = newMessage.channel as TextChannel;
+
+		await sendAuditLog({
+			guild: newMessage.guild,
+			eventType: 'MESSAGE_UPDATE',
+			title: 'Message Edited',
+			fields: [
+				{ name: 'Author', value: newMessage.author?.tag || 'Unknown', inline: true },
+				{ name: 'Channel', value: `${channel} (${channel.name})`, inline: true },
+				{ name: 'Jump to Message', value: `[Click Here](${newMessage.url})`, inline: true },
+				{ name: 'Before', value: truncateString(oldMessage.content || 'Unknown'), inline: false },
+				{ name: 'After', value: truncateString(newMessage.content || 'Unknown'), inline: false }
+			],
+			thumbnail: newMessage.author?.displayAvatarURL(),
+			footer: `Message ID: ${newMessage.id} | Author ID: ${newMessage.author?.id || 'Unknown'}`
+		});
+	}
+}

--- a/src/listeners/logging/roleCreate.ts
+++ b/src/listeners/logging/roleCreate.ts
@@ -1,0 +1,30 @@
+import { Listener } from '@sapphire/framework';
+import { Role } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class RoleCreateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'roleCreate'
+		});
+	}
+
+	public async run(role: Role): Promise<void> {
+		if (!role.guild) return;
+
+		await sendAuditLog({
+			guild: role.guild,
+			eventType: 'ROLE_CREATE',
+			title: 'Role Created',
+			fields: [
+				{ name: 'Role', value: `${role} (${role.name})`, inline: true },
+				{ name: 'Color', value: role.hexColor, inline: true },
+				{ name: 'Hoisted', value: role.hoist ? 'Yes' : 'No', inline: true },
+				{ name: 'Mentionable', value: role.mentionable ? 'Yes' : 'No', inline: true },
+				{ name: 'Position', value: role.position.toString(), inline: true }
+			],
+			footer: `Role ID: ${role.id}`
+		});
+	}
+}

--- a/src/listeners/logging/roleDelete.ts
+++ b/src/listeners/logging/roleDelete.ts
@@ -1,0 +1,28 @@
+import { Listener } from '@sapphire/framework';
+import { Role } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class RoleDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'roleDelete'
+		});
+	}
+
+	public async run(role: Role): Promise<void> {
+		if (!role.guild) return;
+
+		await sendAuditLog({
+			guild: role.guild,
+			eventType: 'ROLE_DELETE',
+			title: 'Role Deleted',
+			fields: [
+				{ name: 'Role Name', value: role.name, inline: true },
+				{ name: 'Color', value: role.hexColor, inline: true },
+				{ name: 'Members', value: role.members.size.toString(), inline: true }
+			],
+			footer: `Role ID: ${role.id}`
+		});
+	}
+}

--- a/src/listeners/logging/roleUpdate.ts
+++ b/src/listeners/logging/roleUpdate.ts
@@ -1,0 +1,60 @@
+import { Listener } from '@sapphire/framework';
+import { Role } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class RoleUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'roleUpdate'
+		});
+	}
+
+	public async run(oldRole: Role, newRole: Role): Promise<void> {
+		if (!newRole.guild) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		if (oldRole.name !== newRole.name) {
+			changes.push({ name: 'Name', value: `${oldRole.name} → ${newRole.name}`, inline: true });
+		}
+
+		if (oldRole.hexColor !== newRole.hexColor) {
+			changes.push({ name: 'Color', value: `${oldRole.hexColor} → ${newRole.hexColor}`, inline: true });
+		}
+
+		if (oldRole.hoist !== newRole.hoist) {
+			changes.push({ name: 'Hoisted', value: `${oldRole.hoist ? 'Yes' : 'No'} → ${newRole.hoist ? 'Yes' : 'No'}`, inline: true });
+		}
+
+		if (oldRole.mentionable !== newRole.mentionable) {
+			changes.push({
+				name: 'Mentionable',
+				value: `${oldRole.mentionable ? 'Yes' : 'No'} → ${newRole.mentionable ? 'Yes' : 'No'}`,
+				inline: true
+			});
+		}
+
+		if (oldRole.permissions.bitfield !== newRole.permissions.bitfield) {
+			changes.push({ name: 'Permissions', value: 'Modified', inline: true });
+		}
+
+		if (oldRole.position !== newRole.position) {
+			changes.push({ name: 'Position', value: `${oldRole.position} → ${newRole.position}`, inline: true });
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild: newRole.guild,
+			eventType: 'ROLE_UPDATE',
+			title: 'Role Updated',
+			fields: [
+				{ name: 'Role', value: `${newRole} (${newRole.name})`, inline: true },
+				{ name: '\u200b', value: '\u200b', inline: true },
+				...changes
+			],
+			footer: `Role ID: ${newRole.id}`
+		});
+	}
+}

--- a/src/listeners/logging/stickerCreate.ts
+++ b/src/listeners/logging/stickerCreate.ts
@@ -1,0 +1,29 @@
+import { Listener } from '@sapphire/framework';
+import { Sticker } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class StickerCreateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'stickerCreate'
+		});
+	}
+
+	public async run(sticker: Sticker): Promise<void> {
+		if (!sticker.guild) return;
+
+		await sendAuditLog({
+			guild: sticker.guild,
+			eventType: 'STICKER_CREATE',
+			title: 'Sticker Created',
+			fields: [
+				{ name: 'Name', value: sticker.name, inline: true },
+				{ name: 'Description', value: sticker.description || 'None', inline: true },
+				{ name: 'Tags', value: sticker.tags || 'None', inline: true }
+			],
+			thumbnail: sticker.url,
+			footer: `Sticker ID: ${sticker.id}`
+		});
+	}
+}

--- a/src/listeners/logging/stickerDelete.ts
+++ b/src/listeners/logging/stickerDelete.ts
@@ -1,0 +1,28 @@
+import { Listener } from '@sapphire/framework';
+import { Sticker } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class StickerDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'stickerDelete'
+		});
+	}
+
+	public async run(sticker: Sticker): Promise<void> {
+		if (!sticker.guild) return;
+
+		await sendAuditLog({
+			guild: sticker.guild,
+			eventType: 'STICKER_DELETE',
+			title: 'Sticker Deleted',
+			fields: [
+				{ name: 'Name', value: sticker.name, inline: true },
+				{ name: 'Description', value: sticker.description || 'None', inline: true }
+			],
+			thumbnail: sticker.url,
+			footer: `Sticker ID: ${sticker.id}`
+		});
+	}
+}

--- a/src/listeners/logging/stickerUpdate.ts
+++ b/src/listeners/logging/stickerUpdate.ts
@@ -1,0 +1,49 @@
+import { Listener } from '@sapphire/framework';
+import { Sticker } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class StickerUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'stickerUpdate'
+		});
+	}
+
+	public async run(oldSticker: Sticker, newSticker: Sticker): Promise<void> {
+		if (!newSticker.guild) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		if (oldSticker.name !== newSticker.name) {
+			changes.push({ name: 'Name', value: `${oldSticker.name} → ${newSticker.name}`, inline: true });
+		}
+
+		if (oldSticker.description !== newSticker.description) {
+			changes.push({
+				name: 'Description',
+				value: `${oldSticker.description || 'None'} → ${newSticker.description || 'None'}`,
+				inline: false
+			});
+		}
+
+		if (oldSticker.tags !== newSticker.tags) {
+			changes.push({
+				name: 'Tags',
+				value: `${oldSticker.tags || 'None'} → ${newSticker.tags || 'None'}`,
+				inline: true
+			});
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild: newSticker.guild,
+			eventType: 'STICKER_UPDATE',
+			title: 'Sticker Updated',
+			fields: [{ name: 'Sticker', value: newSticker.name, inline: true }, ...changes],
+			thumbnail: newSticker.url,
+			footer: `Sticker ID: ${newSticker.id}`
+		});
+	}
+}

--- a/src/listeners/logging/threadCreate.ts
+++ b/src/listeners/logging/threadCreate.ts
@@ -1,0 +1,29 @@
+import { Listener } from '@sapphire/framework';
+import { ThreadChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class ThreadCreateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'threadCreate'
+		});
+	}
+
+	public async run(thread: ThreadChannel, newlyCreated: boolean): Promise<void> {
+		if (!thread.guild || !newlyCreated) return;
+
+		await sendAuditLog({
+			guild: thread.guild,
+			eventType: 'THREAD_CREATE',
+			title: 'Thread Created',
+			fields: [
+				{ name: 'Thread', value: `${thread} (${thread.name})`, inline: true },
+				{ name: 'Parent Channel', value: thread.parent?.name || 'Unknown', inline: true },
+				{ name: 'Owner', value: thread.ownerId ? `<@${thread.ownerId}>` : 'Unknown', inline: true },
+				{ name: 'Auto Archive', value: `${(thread.autoArchiveDuration || 0) / 60} hours`, inline: true }
+			],
+			footer: `Thread ID: ${thread.id}`
+		});
+	}
+}

--- a/src/listeners/logging/threadDelete.ts
+++ b/src/listeners/logging/threadDelete.ts
@@ -1,0 +1,28 @@
+import { Listener } from '@sapphire/framework';
+import { ThreadChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class ThreadDeleteListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'threadDelete'
+		});
+	}
+
+	public async run(thread: ThreadChannel): Promise<void> {
+		if (!thread.guild) return;
+
+		await sendAuditLog({
+			guild: thread.guild,
+			eventType: 'THREAD_DELETE',
+			title: 'Thread Deleted',
+			fields: [
+				{ name: 'Thread Name', value: thread.name, inline: true },
+				{ name: 'Parent Channel', value: thread.parent?.name || 'Unknown', inline: true },
+				{ name: 'Owner', value: thread.ownerId ? `<@${thread.ownerId}>` : 'Unknown', inline: true }
+			],
+			footer: `Thread ID: ${thread.id}`
+		});
+	}
+}

--- a/src/listeners/logging/threadUpdate.ts
+++ b/src/listeners/logging/threadUpdate.ts
@@ -1,0 +1,60 @@
+import { Listener } from '@sapphire/framework';
+import { ThreadChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class ThreadUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'threadUpdate'
+		});
+	}
+
+	public async run(oldThread: ThreadChannel, newThread: ThreadChannel): Promise<void> {
+		if (!newThread.guild) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+
+		if (oldThread.name !== newThread.name) {
+			changes.push({ name: 'Name', value: `${oldThread.name} → ${newThread.name}`, inline: true });
+		}
+
+		if (oldThread.archived !== newThread.archived) {
+			changes.push({ name: 'Archived', value: newThread.archived ? 'Yes' : 'No', inline: true });
+		}
+
+		if (oldThread.locked !== newThread.locked) {
+			changes.push({ name: 'Locked', value: newThread.locked ? 'Yes' : 'No', inline: true });
+		}
+
+		if (oldThread.rateLimitPerUser !== newThread.rateLimitPerUser) {
+			changes.push({
+				name: 'Slowmode',
+				value: `${oldThread.rateLimitPerUser || 0}s → ${newThread.rateLimitPerUser || 0}s`,
+				inline: true
+			});
+		}
+
+		if (oldThread.autoArchiveDuration !== newThread.autoArchiveDuration) {
+			changes.push({
+				name: 'Auto Archive',
+				value: `${(oldThread.autoArchiveDuration || 0) / 60}h → ${(newThread.autoArchiveDuration || 0) / 60}h`,
+				inline: true
+			});
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild: newThread.guild,
+			eventType: 'THREAD_UPDATE',
+			title: 'Thread Updated',
+			fields: [
+				{ name: 'Thread', value: `${newThread} (${newThread.name})`, inline: true },
+				{ name: 'Parent Channel', value: newThread.parent?.name || 'Unknown', inline: true },
+				...changes
+			],
+			footer: `Thread ID: ${newThread.id}`
+		});
+	}
+}

--- a/src/listeners/logging/voiceStateUpdate.ts
+++ b/src/listeners/logging/voiceStateUpdate.ts
@@ -1,0 +1,75 @@
+import { Listener } from '@sapphire/framework';
+import { VoiceState } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class VoiceStateUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'voiceStateUpdate'
+		});
+	}
+
+	public async run(oldState: VoiceState, newState: VoiceState): Promise<void> {
+		const guild = newState.guild || oldState.guild;
+		if (!guild) return;
+
+		const member = newState.member || oldState.member;
+		if (!member || member.user.bot) return;
+
+		const changes: Array<{ name: string; value: string; inline?: boolean }> = [];
+		let title = 'Voice State Updated';
+
+		// User joined a voice channel
+		if (!oldState.channelId && newState.channelId) {
+			title = 'Joined Voice Channel';
+			changes.push({ name: 'Channel', value: `${newState.channel}`, inline: true });
+		}
+		// User left a voice channel
+		else if (oldState.channelId && !newState.channelId) {
+			title = 'Left Voice Channel';
+			changes.push({ name: 'Channel', value: `${oldState.channel}`, inline: true });
+		}
+		// User switched voice channels
+		else if (oldState.channelId !== newState.channelId) {
+			title = 'Switched Voice Channel';
+			changes.push({ name: 'From', value: `${oldState.channel}`, inline: true });
+			changes.push({ name: 'To', value: `${newState.channel}`, inline: true });
+		}
+		// Mute/unmute (server)
+		else if (oldState.serverMute !== newState.serverMute) {
+			title = newState.serverMute ? 'Server Muted' : 'Server Unmuted';
+			changes.push({ name: 'Channel', value: `${newState.channel}`, inline: true });
+		}
+		// Deafen/undeafen (server)
+		else if (oldState.serverDeaf !== newState.serverDeaf) {
+			title = newState.serverDeaf ? 'Server Deafened' : 'Server Undeafened';
+			changes.push({ name: 'Channel', value: `${newState.channel}`, inline: true });
+		}
+		// Streaming
+		else if (oldState.streaming !== newState.streaming) {
+			title = newState.streaming ? 'Started Streaming' : 'Stopped Streaming';
+			changes.push({ name: 'Channel', value: `${newState.channel}`, inline: true });
+		}
+		// Camera
+		else if (oldState.selfVideo !== newState.selfVideo) {
+			title = newState.selfVideo ? 'Camera On' : 'Camera Off';
+			changes.push({ name: 'Channel', value: `${newState.channel}`, inline: true });
+		}
+		// Self mute/unmute and self deafen/undeafen are too noisy, skip them
+		else {
+			return;
+		}
+
+		if (changes.length === 0) return;
+
+		await sendAuditLog({
+			guild,
+			eventType: 'VOICE_STATE_UPDATE',
+			title,
+			fields: [{ name: 'User', value: `${member} (${member.user.tag})`, inline: true }, ...changes],
+			thumbnail: member.displayAvatarURL(),
+			footer: `User ID: ${member.id}`
+		});
+	}
+}

--- a/src/listeners/logging/webhookUpdate.ts
+++ b/src/listeners/logging/webhookUpdate.ts
@@ -1,0 +1,28 @@
+import { Listener } from '@sapphire/framework';
+import { ForumChannel, NewsChannel, TextChannel, VoiceChannel } from 'discord.js';
+import { sendAuditLog } from '../../utils/auditLogger';
+
+export class WebhookUpdateListener extends Listener {
+	public constructor(context: Listener.LoaderContext, options: Listener.Options) {
+		super(context, {
+			...options,
+			event: 'webhookUpdate'
+		});
+	}
+
+	public async run(channel: TextChannel | NewsChannel | VoiceChannel | ForumChannel): Promise<void> {
+		if (!channel.guild) return;
+
+		await sendAuditLog({
+			guild: channel.guild,
+			eventType: 'WEBHOOK_UPDATE',
+			title: 'Webhook Updated',
+			description: `Webhooks in ${channel} were modified.`,
+			fields: [
+				{ name: 'Channel', value: `${channel} (${channel.name})`, inline: true },
+				{ name: 'Channel ID', value: channel.id, inline: true }
+			],
+			footer: `Channel ID: ${channel.id}`
+		});
+	}
+}

--- a/src/utils/auditLogger.ts
+++ b/src/utils/auditLogger.ts
@@ -1,0 +1,147 @@
+import { Colors, EmbedBuilder, Guild, TextChannel } from 'discord.js';
+
+export const LOG_CHANNEL_ID = '1184271264764940388';
+
+export type LogEventType =
+	| 'CHANNEL_CREATE'
+	| 'CHANNEL_DELETE'
+	| 'CHANNEL_UPDATE'
+	| 'MEMBER_JOIN'
+	| 'MEMBER_LEAVE'
+	| 'MEMBER_UPDATE'
+	| 'MEMBER_BAN'
+	| 'MEMBER_UNBAN'
+	| 'MESSAGE_DELETE'
+	| 'MESSAGE_BULK_DELETE'
+	| 'MESSAGE_UPDATE'
+	| 'ROLE_CREATE'
+	| 'ROLE_DELETE'
+	| 'ROLE_UPDATE'
+	| 'INVITE_CREATE'
+	| 'INVITE_DELETE'
+	| 'VOICE_STATE_UPDATE'
+	| 'THREAD_CREATE'
+	| 'THREAD_DELETE'
+	| 'THREAD_UPDATE'
+	| 'EMOJI_CREATE'
+	| 'EMOJI_DELETE'
+	| 'EMOJI_UPDATE'
+	| 'STICKER_CREATE'
+	| 'STICKER_DELETE'
+	| 'STICKER_UPDATE'
+	| 'GUILD_UPDATE'
+	| 'WEBHOOK_UPDATE';
+
+const eventColors: Record<LogEventType, number> = {
+	CHANNEL_CREATE: Colors.Green,
+	CHANNEL_DELETE: Colors.Red,
+	CHANNEL_UPDATE: Colors.Yellow,
+	MEMBER_JOIN: Colors.Green,
+	MEMBER_LEAVE: Colors.Red,
+	MEMBER_UPDATE: Colors.Blue,
+	MEMBER_BAN: Colors.DarkRed,
+	MEMBER_UNBAN: Colors.Green,
+	MESSAGE_DELETE: Colors.Orange,
+	MESSAGE_BULK_DELETE: Colors.DarkOrange,
+	MESSAGE_UPDATE: Colors.Yellow,
+	ROLE_CREATE: Colors.Green,
+	ROLE_DELETE: Colors.Red,
+	ROLE_UPDATE: Colors.Yellow,
+	INVITE_CREATE: Colors.Green,
+	INVITE_DELETE: Colors.Red,
+	VOICE_STATE_UPDATE: Colors.Purple,
+	THREAD_CREATE: Colors.Green,
+	THREAD_DELETE: Colors.Red,
+	THREAD_UPDATE: Colors.Yellow,
+	EMOJI_CREATE: Colors.Green,
+	EMOJI_DELETE: Colors.Red,
+	EMOJI_UPDATE: Colors.Yellow,
+	STICKER_CREATE: Colors.Green,
+	STICKER_DELETE: Colors.Red,
+	STICKER_UPDATE: Colors.Yellow,
+	GUILD_UPDATE: Colors.Blue,
+	WEBHOOK_UPDATE: Colors.Yellow
+};
+
+const eventEmojis: Record<LogEventType, string> = {
+	CHANNEL_CREATE: '📁',
+	CHANNEL_DELETE: '🗑️',
+	CHANNEL_UPDATE: '✏️',
+	MEMBER_JOIN: '📥',
+	MEMBER_LEAVE: '📤',
+	MEMBER_UPDATE: '👤',
+	MEMBER_BAN: '🔨',
+	MEMBER_UNBAN: '🔓',
+	MESSAGE_DELETE: '🗑️',
+	MESSAGE_BULK_DELETE: '🗑️',
+	MESSAGE_UPDATE: '✏️',
+	ROLE_CREATE: '🎭',
+	ROLE_DELETE: '🗑️',
+	ROLE_UPDATE: '✏️',
+	INVITE_CREATE: '📨',
+	INVITE_DELETE: '🗑️',
+	VOICE_STATE_UPDATE: '🎤',
+	THREAD_CREATE: '🧵',
+	THREAD_DELETE: '🗑️',
+	THREAD_UPDATE: '✏️',
+	EMOJI_CREATE: '😀',
+	EMOJI_DELETE: '🗑️',
+	EMOJI_UPDATE: '✏️',
+	STICKER_CREATE: '🏷️',
+	STICKER_DELETE: '🗑️',
+	STICKER_UPDATE: '✏️',
+	GUILD_UPDATE: '🏠',
+	WEBHOOK_UPDATE: '🔗'
+};
+
+export interface AuditLogOptions {
+	guild: Guild;
+	eventType: LogEventType;
+	title: string;
+	description?: string;
+	fields?: Array<{ name: string; value: string; inline?: boolean }>;
+	thumbnail?: string;
+	footer?: string;
+}
+
+export async function getLogChannel(guild: Guild): Promise<TextChannel | null> {
+	const channel = guild.channels.cache.get(LOG_CHANNEL_ID) as TextChannel | undefined;
+
+	return channel || null;
+}
+
+export async function sendAuditLog(options: AuditLogOptions): Promise<void> {
+	const { guild, eventType, title, description, fields, thumbnail, footer } = options;
+
+	const logChannel = await getLogChannel(guild);
+	if (!logChannel) return;
+
+	const embed = new EmbedBuilder().setColor(eventColors[eventType]).setTitle(`${eventEmojis[eventType]} ${title}`).setTimestamp();
+
+	if (description) {
+		embed.setDescription(description);
+	}
+
+	if (fields && fields.length > 0) {
+		embed.addFields(fields);
+	}
+
+	if (thumbnail) {
+		embed.setThumbnail(thumbnail);
+	}
+
+	if (footer) {
+		embed.setFooter({ text: footer });
+	}
+
+	try {
+		await logChannel.send({ embeds: [embed] });
+	} catch (error) {
+		console.error(`Failed to send audit log: ${error}`);
+	}
+}
+
+export function truncateString(str: string, maxLength: number = 1024): string {
+	if (str.length <= maxLength) return str;
+	return str.substring(0, maxLength - 3) + '...';
+}


### PR DESCRIPTION
- Implemented EmojiUpdateListener to log emoji updates.
- Added GuildBanAddListener and GuildBanRemoveListener for member ban/unban events.
- Created GuildMemberRemoveListener to log when members leave the server.
- Introduced GuildMemberUpdateLogListener to track member profile updates.
- Developed GuildUpdateListener to log changes in guild settings.
- Added InviteCreateListener and InviteDeleteListener for invite management.
- Implemented MessageDeleteListener and MessageDeleteBulkListener for message deletions.
- Created MessageUpdateListener to log message edits.
- Added RoleCreateListener, RoleDeleteListener, and RoleUpdateListener for role management.
- Implemented StickerCreateListener, StickerDeleteListener, and StickerUpdateListener for sticker events.
- Developed ThreadCreateListener, ThreadDeleteListener, and ThreadUpdateListener for thread management.
- Added VoiceStateUpdateListener to log voice state changes.
- Created WebhookUpdateListener to log updates to webhooks.
- Introduced auditLogger utility for structured logging and message formatting.